### PR TITLE
#30: No longer returning undefined when colWidth === defaultWidth

### DIFF
--- a/src/grid/Col/style.js
+++ b/src/grid/Col/style.js
@@ -3,7 +3,6 @@ import { defaultGutterWidth, normalizeColumnWidth, screenClasses } from '../../u
 const getWidth = (width, defaultWidth = 12) => {
   if (typeof width !== 'number') return undefined;
   const colWidth = normalizeColumnWidth(width);
-  if (colWidth === defaultWidth) return undefined;
   return `${(100 / 12) * colWidth}%`;
 };
 


### PR DESCRIPTION
This is the second of two possible solutions to this issue. I don't see any reason why we should return `undefined` from getWidth when the col width specified by the consumer of `Col` is `12` (which is what we specify when we want it to span 100%).

I think this is the preferred solution.