### PR TITLE
Use peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ A no CSS Bootstrap-like responsive grid system for React.
 ## Installation
 
 ```
+# Install react peer dependency
+npm install react@16
+
+# Install react grid system
 npm install react-grid-system --save
 ```
 ## Getting started

--- a/package.json
+++ b/package.json
@@ -43,10 +43,12 @@
     "url": "https://github.com/JSxMachina/react-grid-system/issues"
   },
   "homepage": "https://github.com/JSxMachina/react-grid-system#readme",
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
   "dependencies": {
     "lodash": "^4.17.4",
-    "prop-types": "^15.6.0",
-    "react": "^16.0.0"
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
So I am bundling this component in with my app and adding it was adding over 30kb to a single lazily loaded route and I couldn't figure out why. It turns out that it was because I am was using a different React & React DOM version. Since React was listed as a dependency of this module and not a peerDependency then npm actually was installing two versions of React instead of one. 

For libraries like react-grid-system you really want to use peerDependencies to eliminate the possibility of two version of react so this PR changes that and adds instruction to the Readme on how to install using peerDependencies.

The good news: This library works with React 16 (though the version of styleguideist that we're using doesn't seem to)!

