### PR TITLE
Fix typescript definitions and bump version to 3.0.3

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
-import * as React from "react";
-
-declare namespace ReactGridSystem {
+declare module 'react-grid-system' {
+    import * as React from 'react';
     enum Align {
         Normal = "normal",
         Start = "start",
@@ -12,21 +11,21 @@ declare namespace ReactGridSystem {
         sm?: boolean,
         md?: boolean,
         lg?: boolean,
-        xl?: boolean,
+        xl?: boolean
     }
     type Push = {
         xs?: boolean,
         sm?: boolean,
         md?: boolean,
         lg?: boolean,
-        xl?: boolean,
+        xl?: boolean
     }
     type Pull = {
         xs?: boolean,
         sm?: boolean,
         md?: boolean,
         lg?: boolean,
-        xl?: boolean,
+        xl?: boolean
     }
     type ColProps = {
         debug?: boolean,
@@ -39,7 +38,7 @@ declare namespace ReactGridSystem {
         offset?: Offsets,
         push?: Push,
         pull?: Pull,
-
+        style?: object
     }
 
     type ContainerProps = {
@@ -48,13 +47,15 @@ declare namespace ReactGridSystem {
         md?: boolean,
         lg?: boolean,
         xl?: boolean
-        fluid?: boolean
+        fluid?: boolean,
+        style?: object
     }
 
     type RowProps = {
         align?: Align,
         grow?: boolean,
-        debug?: boolean
+        debug?: boolean,
+        style?: object
     }
 
     type ClearFixProps = {
@@ -93,4 +94,3 @@ declare namespace ReactGridSystem {
     export class ScreenClassRender extends React.Component<ScreenClassRenderProps, any> {}
     export class Visible extends React.Component<VisibleProps, any> {}
 }
-export = ReactGridSystem;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-grid-system",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A no CSS Bootstrap-like responsive grid system for React.",
   "main": "./build/index.js",
   "scripts": {
@@ -14,7 +14,8 @@
   "types": "./index.d.ts",
   "files": [
     "build",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
So it turns out I forgot to add index.d.ts to the files array in package.json. This fixes it, fixes the typescript definitions and bumps the version to 3.0.3.