### PR TITLE
Edit offset types so number instead of booleans

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,11 +7,11 @@ declare module 'react-grid-system' {
         End = "end"
     }
     type Offsets = {
-        xs?: boolean,
-        sm?: boolean,
-        md?: boolean,
-        lg?: boolean,
-        xl?: boolean
+        xs?: number,
+        sm?: number,
+        md?: number,
+        lg?: number,
+        xl?: number
     }
     type Push = {
         xs?: boolean,


### PR DESCRIPTION
Type errors for boolean when using in our React/typescript/nextjs project, as the offset value is a number, changing the type to number fixes the type error so that project is now compiling normally and pass tests.