### PR TITLE
Fix #60 - Use Union type instead of enum with Align

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,6 @@
 declare module 'react-grid-system' {
-    import * as React from 'react';
-    enum Align {
-        Normal = "normal",
-        Start = "start",
-        Center = "center",
-        End = "end"
-    }
+    import * as React from 'react'
+    type Align = "normal" | "start" | "center" | "end"
     type Offsets = {
         xs?: number,
         sm?: number,


### PR DESCRIPTION
Fixes the error in #60 .

Change from `enum` to `union` type for Align prop. Now it works with TypeScript in the way the documentation explains it.