### PR TITLE
Fix component prop type validation

### DIFF
--- a/src/grid/Col/index.jsx
+++ b/src/grid/Col/index.jsx
@@ -79,7 +79,7 @@ export default class Col extends React.Component {
      * Use your own component
      */
     component: PropTypes.oneOfType([
-      PropTypes.element,
+      PropTypes.func,
       PropTypes.string,
     ]),
   };

--- a/src/grid/Container/index.jsx
+++ b/src/grid/Container/index.jsx
@@ -53,7 +53,7 @@ export default class Container extends React.Component {
      * Use your own component
      */
     component: PropTypes.oneOfType([
-      PropTypes.element,
+      PropTypes.func,
       PropTypes.string,
     ]),
   };

--- a/src/grid/Row/index.jsx
+++ b/src/grid/Row/index.jsx
@@ -34,7 +34,7 @@ export default class Row extends React.Component {
      * Use your own component
      */
     component: PropTypes.oneOfType([
-      PropTypes.element,
+      PropTypes.func,
       PropTypes.string,
     ]),
   };


### PR DESCRIPTION
**Fix component prop type validation**
react-grid-system version: 4.2.0
chrome version: 68.0.3440.106

**Description**
After passing `component` property to any of `Contrainer`, `Col`, `Row`, following warnings are visible in the console.

```Failed prop type: Invalid prop `component` supplied to `Contrainer`.```
```Failed prop type: Invalid prop `component` supplied to `Col`.```
```Failed prop type: Invalid prop `component` supplied to `Row`.```

**Used code**
- I am trying to render styles using glamorous library, so I do not have long style attributes in the DOM.
```jsx
import * as reactGridSystem from "react-grid-system";
import glamorous from "glamorous";
import React, { Component } from "react";

class ProxyComponent extends Component {
  render () {
    const { style, ...rest } = this.props;
    const Component = glamorous.div(style);
    return <Component {...rest} />;
  }
}

export const Container = props => <reactGridSystem.Container {...props} component={ProxyComponent} />;
export const Row = props => <reactGridSystem.Row {...props} component={ProxyComponent} />;
export const Col = props => <reactGridSystem.Col {...props} component={ProxyComponent} />;
```

**Expected behaviour**
No warnings in the console when passing react component as a `component` property.

**Live example**
https://codesandbox.io/s/zkl6nmlrjx