### PR TITLE
Ability to use own dimensions instead of window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5337,12 +5337,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5357,17 +5359,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5484,7 +5489,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5496,6 +5502,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5510,6 +5517,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5517,12 +5525,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5541,6 +5551,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5621,7 +5632,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5633,6 +5645,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5754,6 +5767,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/context/ScreenClassProvider/index.jsx
+++ b/src/context/ScreenClassProvider/index.jsx
@@ -64,7 +64,7 @@ export default class ScreenClassProvider extends PureComponent {
       <ScreenClassContext.Provider value={screenClass}>
         {useOwnWidth
           ? <div ref={this.screenClassRef}>{children}</div>
-          : { children }
+          : <React.Fragment>{children}</React.Fragment>
         }
       </ScreenClassContext.Provider>
     );

--- a/src/context/ScreenClassProvider/index.jsx
+++ b/src/context/ScreenClassProvider/index.jsx
@@ -53,10 +53,8 @@ export default class ScreenClassProvider extends PureComponent {
       console.log(this.screenClassRef);
     }
 
-    const screenClassSource = useSelfAsSource && this.screenClassRef
-      ? this.screenClassRef.current
-      : undefined;
-    const currScreenClass = getScreenClass({ source: screenClassSource });
+    const source = useSelfAsSource && this.screenClassRef ? this.screenClassRef.current : undefined;
+    const currScreenClass = getScreenClass({ source });
     if (currScreenClass !== this.state.screenClass) {
       this.setState({ screenClass: currScreenClass });
     }
@@ -64,11 +62,14 @@ export default class ScreenClassProvider extends PureComponent {
 
   render() {
     const { screenClass } = this.state;
-    const { children } = this.props;
+    const { children, useSelfAsSource } = this.props;
 
     return (
-      <ScreenClassContext.Provider value={screenClass} ref={this.screenClassRef}>
-        {children}
+      <ScreenClassContext.Provider value={screenClass}>
+        {useSelfAsSource
+          ? <div ref={this.screenClassRef}>{children}</div>
+          : <>{children}</>
+        }
       </ScreenClassContext.Provider>
     );
   }

--- a/src/context/ScreenClassProvider/index.jsx
+++ b/src/context/ScreenClassProvider/index.jsx
@@ -64,7 +64,7 @@ export default class ScreenClassProvider extends PureComponent {
       <ScreenClassContext.Provider value={screenClass}>
         {useOwnWidth
           ? <div ref={this.screenClassRef}>{children}</div>
-          : <React.Fragment>{children}</React.Fragment>
+          : { children }
         }
       </ScreenClassContext.Provider>
     );

--- a/src/context/ScreenClassProvider/index.jsx
+++ b/src/context/ScreenClassProvider/index.jsx
@@ -68,7 +68,7 @@ export default class ScreenClassProvider extends PureComponent {
       <ScreenClassContext.Provider value={screenClass}>
         {useSelfAsSource
           ? <div ref={this.screenClassRef}>{children}</div>
-          : <>{children}</>
+          : <React.Fragment>{children}</React.Fragment>
         }
       </ScreenClassContext.Provider>
     );

--- a/src/context/ScreenClassProvider/index.jsx
+++ b/src/context/ScreenClassProvider/index.jsx
@@ -15,11 +15,21 @@ export default class ScreenClassProvider extends PureComponent {
      * This should be all your child React nodes that are using `react-grid-system`.
      */
     children: PropTypes.node.isRequired,
+    /**
+     * Boolean to determine wether self should be used as source.
+     * When provided, screen class is derived from self instead of the window.
+     */
+    useSelfAsSource: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    useSelfAsSource: false,
   };
 
   constructor(props) {
     super(props);
 
+    this.screenClassRef = React.createRef();
     this.state = {
       screenClass: getConfiguration().defaultScreenClass,
     };
@@ -37,7 +47,12 @@ export default class ScreenClassProvider extends PureComponent {
   }
 
   setScreenClass() {
-    const currScreenClass = getScreenClass();
+    const { useSelfAsSource } = this.props;
+
+    const screenClassSource = useSelfAsSource && this.screenClassRef
+      ? this.screenClassRef.current
+      : undefined;
+    const currScreenClass = getScreenClass({ source: screenClassSource });
     if (currScreenClass !== this.state.screenClass) {
       this.setState({ screenClass: currScreenClass });
     }
@@ -48,7 +63,9 @@ export default class ScreenClassProvider extends PureComponent {
     const { children } = this.props;
 
     return (
-      <ScreenClassContext.Provider value={screenClass}>{children}</ScreenClassContext.Provider>
+      <ScreenClassContext.Provider value={screenClass} ref={this.screenClassRef}>
+        {children}
+      </ScreenClassContext.Provider>
     );
   }
 }

--- a/src/context/ScreenClassProvider/index.jsx
+++ b/src/context/ScreenClassProvider/index.jsx
@@ -16,24 +16,24 @@ export default class ScreenClassProvider extends PureComponent {
      */
     children: PropTypes.node.isRequired,
     /**
-     * Boolean to determine wether self should be used as source.
-     * When provided, screen class is derived from self instead of the window.
+     * Boolean to determine whether own width should be used as source.
+     * When provided, the screen class is derived from own dimensions instead of the window.
      */
-    useSelfAsSource: PropTypes.bool,
+    useOwnWidth: PropTypes.bool,
   };
 
   static defaultProps = {
-    useSelfAsSource: false,
+    useOwnWidth: false,
   };
 
   constructor(props) {
     super(props);
 
-    this.screenClassRef = React.createRef();
     this.state = {
       screenClass: getConfiguration().defaultScreenClass,
     };
 
+    this.screenClassRef = React.createRef();
     this.setScreenClass = this.setScreenClass.bind(this);
   }
 
@@ -47,14 +47,10 @@ export default class ScreenClassProvider extends PureComponent {
   }
 
   setScreenClass() {
-    const { useSelfAsSource } = this.props;
+    const { useOwnWidth } = this.props;
 
-    if (useSelfAsSource) {
-      console.log(this.screenClassRef);
-    }
-
-    const source = useSelfAsSource && this.screenClassRef ? this.screenClassRef.current : undefined;
-    const currScreenClass = getScreenClass({ source });
+    const source = useOwnWidth && this.screenClassRef && this.screenClassRef.current;
+    const currScreenClass = getScreenClass(source);
     if (currScreenClass !== this.state.screenClass) {
       this.setState({ screenClass: currScreenClass });
     }
@@ -62,11 +58,11 @@ export default class ScreenClassProvider extends PureComponent {
 
   render() {
     const { screenClass } = this.state;
-    const { children, useSelfAsSource } = this.props;
+    const { children, useOwnWidth } = this.props;
 
     return (
       <ScreenClassContext.Provider value={screenClass}>
-        {useSelfAsSource
+        {useOwnWidth
           ? <div ref={this.screenClassRef}>{children}</div>
           : <React.Fragment>{children}</React.Fragment>
         }

--- a/src/context/ScreenClassProvider/index.jsx
+++ b/src/context/ScreenClassProvider/index.jsx
@@ -49,6 +49,10 @@ export default class ScreenClassProvider extends PureComponent {
   setScreenClass() {
     const { useSelfAsSource } = this.props;
 
+    if (useSelfAsSource) {
+      console.log(this.screenClassRef);
+    }
+
     const screenClassSource = useSelfAsSource && this.screenClassRef
       ? this.screenClassRef.current
       : undefined;

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,7 @@
 import { getConfiguration } from './config';
 
 const getViewPort = (source) => {
-  if (typeof source !== 'undefined' && source.clientWidth) {
+  if (source && source.clientWidth) {
     return source.clientWidth;
   }
   if (typeof window !== 'undefined' && window.innerWidth) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,9 @@
 import { getConfiguration } from './config';
 
 const getViewPort = (source) => {
+  if (source) {
+    console.log(source);
+  }
   if (source && source.clientWidth) {
     return source.clientWidth;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,9 +4,6 @@
 import { getConfiguration } from './config';
 
 const getViewPort = (source) => {
-  if (source) {
-    console.log(source);
-  }
   if (source && source.clientWidth) {
     return source.clientWidth;
   }
@@ -18,7 +15,7 @@ const getViewPort = (source) => {
 
 export const screenClasses = ['xs', 'sm', 'md', 'lg', 'xl'];
 
-export const getScreenClass = ({ source }) => {
+export const getScreenClass = (source) => {
   const { breakpoints, defaultScreenClass } = getConfiguration();
   let screenClass = defaultScreenClass;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,10 @@
 
 import { getConfiguration } from './config';
 
-const getViewPort = () => {
+const getViewPort = (source) => {
+  if (typeof source !== 'undefined' && source.clientWidth) {
+    return source.clientWidth;
+  }
   if (typeof window !== 'undefined' && window.innerWidth) {
     return window.innerWidth;
   }
@@ -12,11 +15,11 @@ const getViewPort = () => {
 
 export const screenClasses = ['xs', 'sm', 'md', 'lg', 'xl'];
 
-export const getScreenClass = () => {
+export const getScreenClass = ({ source }) => {
   const { breakpoints, defaultScreenClass } = getConfiguration();
   let screenClass = defaultScreenClass;
 
-  const viewport = getViewPort();
+  const viewport = getViewPort(source);
   if (viewport) {
     screenClass = 'xs';
     if (breakpoints[0] && viewport >= breakpoints[0]) screenClass = 'sm';


### PR DESCRIPTION
Added a prop called `useOwnWidth` to the `ScreenClassProvider` component.
When provided, it adds a container and uses that as source for the screenclass dimensions.