### PR TITLE
Update 'align' prop validation

### DIFF
--- a/src/grid/Readme.md
+++ b/src/grid/Readme.md
@@ -113,6 +113,12 @@ Resize your browser or load on different devices to test the grid system.
     <Col debug>2 of 3</Col>
     <Col debug>3 of 3</Col>
   </Row>
+  <br />
+  <Row align="stretch" debug>
+    <Col debug>1 of 3</Col>
+    <Col debug>2 of 3</Col>
+    <Col debug>3 of 3</Col>
+  </Row>
 </Container>
 ```
 

--- a/src/grid/Row/index.jsx
+++ b/src/grid/Row/index.jsx
@@ -14,7 +14,7 @@ export default class Row extends React.PureComponent {
     /**
      * Vertical column alignment
      */
-    align: PropTypes.oneOf(['normal', 'start', 'center', 'end']),
+    align: PropTypes.oneOf(['normal', 'start', 'center', 'end', 'stretch']),
     /**
      * Horizontal column alignment
      */


### PR DESCRIPTION
Add flex box option 'stretch' to the align prop so you can set columns inside a row to be equal heights.

Also add the new option into the readme.