### PR TITLE
Fix typings for ScreenClassProvider props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ declare module 'react-grid-system' {
     }
 
     type ScreenClassProviderProps = {
-        children: Function
+        children: React.ReactNode
     }
 
     export function setConfiguration(configuration: Configuration): void


### PR DESCRIPTION
Fixed typings for `ScreenClassProvider` children prop.

Fixes #92 