### PR TITLE
Add nowrap option to Row

### DIFF
--- a/src/grid/Row/index.jsx
+++ b/src/grid/Row/index.jsx
@@ -52,6 +52,10 @@ export default class Row extends React.PureComponent {
       PropTypes.func,
       PropTypes.string,
     ]),
+    /**
+     * Whether the cols should not wrap
+     */
+    nowrap: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -74,6 +78,7 @@ export default class Row extends React.PureComponent {
       nogutter,
       gutterWidth,
       component,
+      nowrap,
       ...otherProps
     } = this.props;
     let theGutterWidth = getConfiguration().gutterWidth;
@@ -85,6 +90,7 @@ export default class Row extends React.PureComponent {
       justify,
       debug,
       moreStyle: style,
+      nowrap,
     });
     return React.createElement(
       component,

--- a/src/grid/Row/style.js
+++ b/src/grid/Row/style.js
@@ -1,5 +1,5 @@
 export default ({
-  gutterWidth, align, justify, debug, moreStyle,
+  gutterWidth, align, justify, debug, moreStyle, nowrap,
 }) => {
   // Vertical alignment
   let alignItems = align;
@@ -20,7 +20,7 @@ export default ({
     marginLeft: `-${gutterWidth / 2}px`,
     marginRight: `-${gutterWidth / 2}px`,
     display: 'flex',
-    flexWrap: 'wrap',
+    flexWrap: nowrap ? 'nowrap' : 'wrap',
     flexGrow: 0,
     flexShrink: 0,
     alignItems,


### PR DESCRIPTION
This PR addresses #102

It adds a `nowrap` prop to `Row` that simply sets the `flex-wrap` css property to `nowrap`. 

Especially useful when using the `content` Col sizing as described in #104 .

```
<Row>
  <Col xs="content">very long content...</Col>
  <Col></Col>
</Row>
```